### PR TITLE
added missing version number of lib "libmozjs-dev"

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -166,7 +166,7 @@ def install_couchdb():
     require.deb.packages([
         'erlang',
         'libicu-dev',
-        'libmozjs-dev',
+        'libmozjs185-dev',
         'libcurl4-openssl-dev',
         'curl'
     ])


### PR DESCRIPTION
When compilating, an error occured - Unknown version of libmozjs-dev on Debian 7 Wheezy Stable.
Adding "185" before "-dev" solved the problem - compilation successfully work after this.
