### PR TITLE
Change nginx version and configuration

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -552,6 +552,9 @@ server {
     ssl_ciphers  ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv3:+EXP;
     ssl_prefer_server_ciphers   on;
     ssl on;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
 
     gzip_vary on;
 
@@ -572,7 +575,7 @@ def install_nginx():
     """
     Install NGINX and make it use certs.
     """
-    require.deb.package("nginx")
+    require.deb.ppa("ppa:nginx/stable")
     require.nginx.site("cozy",
         template_contents=PROXIED_SITE_TEMPLATE,
         enabled=True,


### PR DESCRIPTION
Nginx version depends of ubuntu version : 
Maverick = 1.2.7
Lucid, Natty, Oneiric = 1.4.1
Precise, Quantal, Raring, and Saucy > 1.4.1

Script stops during installation (user should press ENTER). This pause will be remove with new version of fabtools : https://github.com/ronnix/fabtools/pull/103
