### PR TITLE
install python-dev, required to compile lxml

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -131,6 +131,7 @@ def install_tools():
     deb.upgrade()
     require.deb.packages([
         'python',
+        'python-dev',
         'python-setuptools',
         'python-pip',
         'openssl',


### PR DESCRIPTION
lxml requires `Python.h` in order to be compiled, which is provided by the package python-dev. It's not installed by default on Debian (tested on a Raspbian) so the fabric process fails with the following error:

```
[pi@192.168.2.78] out: src/lxml/lxml.etree.c:16:20: fatal error: Python.h: No such file or directory
[pi@192.168.2.78] out: 
[pi@192.168.2.78] out: compilation terminated.
[pi@192.168.2.78] out: 
[pi@192.168.2.78] out: error: command 'gcc' failed with exit status 1
```
