### PR TITLE
fix a typo in the is_pi() function

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -42,7 +42,7 @@ TOKEN = simple_id_generator()
 
 @task
 def is_pi():
-    result = run('Lscpu', quiet=True)
+    result = run('lscpu', quiet=True)
     return 'armv6l' in result
 
 


### PR DESCRIPTION
fix a typo in the is_pi() function which resulted in having to build from source node.js on a raspberry pi
