### PR TITLE
Fix error introduced in last commit

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -226,8 +226,8 @@ def install_node10():
 
     if is_pi():
         version = '0.10.26'
-        require_file(url='http://nodejs.org/dist/v{0}/'
-                            + 'node-v{0}-linux-arm-pi.tar.gz'.format(version))
+        node_url = 'http://nodejs.org/dist/v{0}/node-v{0}-linux-arm-pi.tar.gz'
+        require_file(url=node_url.format(version))
         run('tar -xzvf node-v%s-linux-arm-pi.tar.gz' % version)
         delete_if_exists('/opt/node')
         sudo('mkdir /opt/node')


### PR DESCRIPTION
I made a last minute change in last commit (e4f92a9a8d2f0adc644479d431834c2bacfbf8ba) to conform to PEP8 (Line length), and I made a mistake with the format method.

This commit fixes this error, I tested it, sorry for this.
