### PR TITLE
Updated ez_setup URL

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,7 @@ requirements="fabric fabtools"
 
 if [[ "$VIRTUAL_ENV" == "" ]]; then
     curl -o - https://bootstrap.pypa.io/ez_setup.py -O - | python
-    curl -o - https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py | python -
+    curl -o - https://bootstrap.pypa.io/get-pip.py | python -
 fi
 
 pip install -U $requirements


### PR DESCRIPTION
Changed the URL to download ez_setup according to the the new URL (see
https://bitbucket.org/pypa/setuptools/issue/192/any-attempt-to-download-ez_setuppy-fails
for details)
