### PR TITLE
Fix Cozy Monitor install

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -294,7 +294,7 @@ def uninstall_node10():
         sudo('make uninstall')
         sudo('make distclean')
     su_delete('%s*' % folder)
-    print(green('Node 0.10.26 successfully uninstalled'))
+    print(green('Node {0} successfully uninstalled'.format(version)))
 
 
 @task
@@ -594,9 +594,8 @@ def install_indexer():
 
     require.python.virtualenv(indexer_env_dir, use_sudo=True)
     with python.virtualenv(indexer_env_dir):
-        sudo(
-            'pip install --use-mirrors -r %s/requirements/common.txt' %
-            indexer_dir)
+        python.install_requirements(
+            indexer_dir + '/requirements/common.txt', use_sudo=True)
 
     sudo('chown -R cozy:cozy %s' % home)
 
@@ -863,9 +862,9 @@ def update_indexer():
         sudo('git pull origin master')
 
     with python.virtualenv(indexer_env_dir):
-        sudo(
-            'pip install --use-mirrors --upgrade -r '
-            '%s/requirements/common.txt' % indexer_dir)
+        python.install_requirements(indexer_dir + '/requirements/common.txt',
+                                    upgrade=True, use_sudo=True)
+
     supervisor.restart_process('cozy-indexer')
 
 


### PR DESCRIPTION
there is a bug in the current version of
`fabtools.nodejs.package_version()`, used by the
`fabtools.require.nodejs.package()` function, which has been fixed in
the git repository but is not yet present in the release (see
https://github.com/ronnix/fabtools/commit/45fdb3a2bed6798afa80fa4fe7bd284c55b67862).
I switched back to the old installation method, until the fix is
released.
