### PR TITLE
Changed: uninstalling CouchDB also uninstall its dependencies

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -821,6 +821,8 @@ def uninstall_couchdb():
     su_delete('apache-couchdb-%s.tar.gz' % version)
     su_delete('/etc/supervisor/conf.d/couchdb.conf')
     su_delete('/etc/cozy/couchdb.login')
+    # removes dependency of CouchDB
+    require.deb.uninstall('erlang', False, ['--auto-remove'])
     supervisor.update_config()
     print(green('CouchDB %s successfully uninstalled' % version))
 


### PR DESCRIPTION
This **partly** (see comment below) fixes #108.
Here is the list of Couch dependencies: http://docs.couchdb.org/en/latest/install/unix.html#dependencies

I found Erlang the only one noticeable but if you think other should be uninstalled too, let me know. If it's okay then the issue is **fully** fixed.
