### PR TITLE
Add nginx conf to hook port 80 and redirect to 443 (https) Refs #111

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -578,6 +578,13 @@ server {
 
     access_log /var/log/nginx/%(server_name)s.log;
 }
+
+#Hook to redirect http:// to https://
+server {
+       listen 80;
+       return 301 https://$host$request_uri;
+}
+
 '''
 
 


### PR DESCRIPTION
As resquested.

This should be follow by the opening of port 80 on the  modem, home-router,... to be effective from the web.