### PR TITLE
add wget in tools

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -181,7 +181,8 @@ def install_tools():
                 'lsb-release',
                 'imagemagick',
                 'curl',
-                'sqlite3']
+                'sqlite3',
+                'wget']
 
     if system.distrib_id() == 'Ubuntu':
         packages.append('software-properties-common')


### PR DESCRIPTION
Hi,

debian debootstrap don't install wget by default.
This PR fix this issue

Regards,
Yann