### PR TITLE
Use the ARM-Pi version of NodeJS for standard ARM hosts as well as RPi

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -41,10 +41,14 @@ PASSWORD = id_generator()
 TOKEN = simple_id_generator()
 
 
-@task
 def is_pi():
     result = run('lscpu', quiet=True)
     return 'armv6l' in result
+
+
+def is_arm():
+    result = run('lscpu', quiet=True)
+    return 'armv' in result
 
 
 def print_failed(module):
@@ -204,7 +208,7 @@ def install_node10():
     install node 0.10.26
     '''
 
-    if is_pi():
+    if is_arm():
         with settings(warn_only=True):
             result = run('node -v')
             is_installed = result.find('v0.10.26')


### PR DESCRIPTION
We were using a specific Node version for the RaspberryPi / Pi2, and I extended this use to all ARM based hosts:
http://nodejs.org/dist/v0.10.26/node-v0.10.26-linux-arm-pi.tar.gz

This version is actually a build of NodeJS without the 'snapshot' feature, which is incompatible with the ARM architecture, although reducing the Node launching time slightly.

It works perfectly fine like this on armv6/7/8

Closing #138 