### PR TITLE
Bind cozy-proxy on localhost

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -393,7 +393,7 @@ def install_controller():
     require.supervisor.process(
         'cozy-controller',
         command='cozy-controller',
-        environment='NODE_ENV="production"',
+        environment='NODE_ENV="production",BIND_IP_PROXY="127.0.0.1"',
         user='root'
     )
 


### PR DESCRIPTION
This is more secure on a self hosted installation, and avoid some issue kind this one #129