### PR TITLE
[fix] Install 1.6 only on x86_64 hosts

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -604,7 +604,7 @@ def install_nginx():
     Install NGINX and make it use certs.
     '''
     if system.distrib_id() == 'Debian':
-        if not is_pi():
+        if not is_arm():
             key_url = 'http://nginx.org/packages/keys/nginx_signing.key'
             require.file(url=key_url)
             deb.add_apt_key('nginx_signing.key')


### PR DESCRIPTION
The Nginx official repository does not contain a "armhf" build of Nginx.
Do not try to add it on "armhf" hosts :+1: 