### PR TITLE
Remove update of indexer

### DIFF
--- a/dev/update-devenv.sh
+++ b/dev/update-devenv.sh
@@ -23,14 +23,3 @@ sudo npm install -g cozy-monitor
 
 sudo supervisorctl start cozy-controller
 
-# Update the indexer
-sudo supervisorctl stop cozy-indexer
-cd /usr/local/var/cozy-indexer/cozy-data-indexer
-sudo rm -rf indexes # to prevent issues
-sudo git pull origin master
-sudo virtualenv virtualenv
-. virtualenv/bin/activate
-sudo pip install -r requirements/common.txt --upgrade
-sudo pip install -r requirements/production.txt --upgrade
-sudo supervisorctl start cozy-indexer
-


### PR DESCRIPTION
Since cozy-indexer is now part of the data system, there is no reason to try to update it (also, it fails if we try).